### PR TITLE
Fix #1: Add asChild to DialogTrigger to prevent hydration errors

### DIFF
--- a/src/app/(app)/[workspaceSlug]/settings/api-keys/api-keys-client.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/api-keys/api-keys-client.tsx
@@ -81,7 +81,7 @@ export function ApiKeysClient({ workspaceId, workspaceSlug, memberId }: ApiKeysC
         </div>
         <Dialog open={createOpen} onOpenChange={setCreateOpen}>
 
-          <DialogTrigger>
+          <DialogTrigger asChild>
             <Button>
               <Plus className="h-4 w-4 mr-1.5" />
               Create API Key

--- a/src/app/(app)/[workspaceSlug]/settings/integrations/integrations-client.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/integrations/integrations-client.tsx
@@ -160,7 +160,7 @@ export function IntegrationsClient({
               </div>
             </div>
             <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-              <DialogTrigger>
+              <DialogTrigger asChild>
                 <Button size="sm">
                   <Plus className="h-4 w-4 mr-1.5" />
                   Add Webhook


### PR DESCRIPTION
Resolves #1

## Changes
- Added `asChild` prop to `<DialogTrigger>` components that wrap `<Button>` elements on the API Keys and Integrations settings pages
- This prevents nested `<button>` elements in the DOM which caused React hydration mismatches

## Root Cause
`<DialogTrigger>` renders a `<button>` by default. When wrapping a shadcn `<Button>` component (which also renders a `<button>`), this creates invalid nested button HTML.