### PR TITLE
Fix #2: Guard subscribe calls against undefined channel/store

### DIFF
--- a/src/hooks/use-messages.ts
+++ b/src/hooks/use-messages.ts
@@ -42,8 +42,10 @@ export function useMessages(channelId: string) {
     // after subscribe()" errors when React re-runs effects before the async
     // removeChannel() from the previous cleanup has completed.
     const subId = Math.random().toString(36).slice(2);
-    const channel = supabase
-      .channel(`messages:${channelId}:${subId}`)
+    const channel = supabase.channel(`messages:${channelId}:${subId}`);
+    if (!channel) return;
+
+    channel
       .on(
         "postgres_changes",
         {
@@ -59,7 +61,7 @@ export function useMessages(channelId: string) {
       .subscribe();
 
     return () => {
-      supabase.removeChannel(channel);
+      if (channel) supabase.removeChannel(channel);
     };
   }, [channelId, supabase, queryClient]);
 

--- a/src/hooks/use-messages.ts
+++ b/src/hooks/use-messages.ts
@@ -58,7 +58,7 @@ export function useMessages(channelId: string) {
           queryClient.invalidateQueries({ queryKey: ["messages", channelId] });
         }
       )
-      .subscribe();
+      ?.subscribe();
 
     return () => {
       if (channel) supabase.removeChannel(channel);

--- a/src/hooks/use-notifications.ts
+++ b/src/hooks/use-notifications.ts
@@ -31,8 +31,13 @@ export function useNotifications(userId: string) {
   useEffect(() => {
     if (!userId) return;
 
-    const channel = supabase
-      .channel(`notifications:${userId}`)
+    // Use a unique name per effect invocation to avoid stale channel name
+    // collisions when React re-runs effects before async cleanup completes.
+    const subId = Math.random().toString(36).slice(2);
+    const channel = supabase.channel(`notifications:${userId}:${subId}`);
+    if (!channel) return;
+
+    channel
       .on(
         "postgres_changes",
         {
@@ -52,7 +57,7 @@ export function useNotifications(userId: string) {
       .subscribe();
 
     return () => {
-      supabase.removeChannel(channel);
+      if (channel) supabase.removeChannel(channel);
     };
   }, [userId, supabase, queryClient]);
 

--- a/src/hooks/use-notifications.ts
+++ b/src/hooks/use-notifications.ts
@@ -54,7 +54,7 @@ export function useNotifications(userId: string) {
           toast.info(notification.title);
         }
       )
-      .subscribe();
+      ?.subscribe();
 
     return () => {
       if (channel) supabase.removeChannel(channel);

--- a/src/hooks/use-presence.ts
+++ b/src/hooks/use-presence.ts
@@ -18,9 +18,15 @@ export function usePresence(workspaceId: string, userId: string) {
   useEffect(() => {
     if (!workspaceId || !userId) return;
 
-    const channel = supabase.channel(`presence:${workspaceId}`, {
+    // Use a unique name per effect invocation to avoid stale channel name
+    // collisions when React re-runs effects before async cleanup completes.
+    const subId = Math.random().toString(36).slice(2);
+    const channel = supabase.channel(`presence:${workspaceId}:${subId}`, {
       config: { presence: { key: userId } },
     });
+    if (!channel) return;
+
+    let cleaned = false;
 
     channel
       .on("presence", { event: "sync" }, () => {
@@ -34,7 +40,7 @@ export function usePresence(workspaceId: string, userId: string) {
         setOnlineUsers(users);
       })
       .subscribe(async (status) => {
-        if (status === "SUBSCRIBED") {
+        if (status === "SUBSCRIBED" && !cleaned) {
           await channel.track({
             user_id: userId,
             status: "online",
@@ -46,6 +52,7 @@ export function usePresence(workspaceId: string, userId: string) {
     // Track away status after 5 min idle
     let idleTimeout: ReturnType<typeof setTimeout>;
     const resetIdle = () => {
+      if (cleaned) return;
       clearTimeout(idleTimeout);
       channel.track({
         user_id: userId,
@@ -53,6 +60,7 @@ export function usePresence(workspaceId: string, userId: string) {
         last_seen: new Date().toISOString(),
       });
       idleTimeout = setTimeout(() => {
+        if (cleaned) return;
         channel.track({
           user_id: userId,
           status: "away",
@@ -65,7 +73,8 @@ export function usePresence(workspaceId: string, userId: string) {
     window.addEventListener("keydown", resetIdle);
 
     return () => {
-      supabase.removeChannel(channel);
+      cleaned = true;
+      if (channel) supabase.removeChannel(channel);
       clearTimeout(idleTimeout);
       window.removeEventListener("mousemove", resetIdle);
       window.removeEventListener("keydown", resetIdle);

--- a/src/hooks/use-presence.ts
+++ b/src/hooks/use-presence.ts
@@ -39,7 +39,7 @@ export function usePresence(workspaceId: string, userId: string) {
         });
         setOnlineUsers(users);
       })
-      .subscribe(async (status) => {
+      ?.subscribe(async (status) => {
         if (status === "SUBSCRIBED" && !cleaned) {
           await channel.track({
             user_id: userId,
@@ -54,14 +54,14 @@ export function usePresence(workspaceId: string, userId: string) {
     const resetIdle = () => {
       if (cleaned) return;
       clearTimeout(idleTimeout);
-      channel.track({
+      channel?.track({
         user_id: userId,
         status: "online",
         last_seen: new Date().toISOString(),
       });
       idleTimeout = setTimeout(() => {
         if (cleaned) return;
-        channel.track({
+        channel?.track({
           user_id: userId,
           status: "away",
           last_seen: new Date().toISOString(),

--- a/src/hooks/use-typing.ts
+++ b/src/hooks/use-typing.ts
@@ -14,6 +14,8 @@ export function useTyping(channelId: string, displayName: string) {
 
     const subId = Math.random().toString(36).slice(2);
     const channel = supabase.channel(`typing:${channelId}:${subId}`);
+    if (!channel) return;
+
     channelRef.current = channel;
 
     channel
@@ -33,7 +35,7 @@ export function useTyping(channelId: string, displayName: string) {
       .subscribe();
 
     return () => {
-      supabase.removeChannel(channel);
+      if (channel) supabase.removeChannel(channel);
       channelRef.current = null;
     };
   }, [channelId, displayName, supabase]);

--- a/src/hooks/use-typing.ts
+++ b/src/hooks/use-typing.ts
@@ -32,7 +32,7 @@ export function useTyping(channelId: string, displayName: string) {
           setTypingUsers((prev) => prev.filter((n) => n !== name));
         }, 3000);
       })
-      .subscribe();
+      ?.subscribe();
 
     return () => {
       if (channel) supabase.removeChannel(channel);


### PR DESCRIPTION
Resolves #2

## Changes
- Added null/undefined guards to all `.subscribe()` calls on Supabase realtime channels
- Added unique `subId` to `use-notifications.ts` and `use-presence.ts` channel names to prevent stale channel name collisions (matching the pattern from the previous fix in `use-messages.ts` and `use-typing.ts`)
- Added `cleaned` flag in `use-presence.ts` to prevent `channel.track()` calls from firing after cleanup (idle timeout handlers could reference a removed channel)
- Guarded `removeChannel()` calls in all cleanup functions

## Root Cause
Supabase channel objects could be undefined when `.subscribe()` was called, causing uncaught runtime errors. Additionally, `use-notifications.ts` and `use-presence.ts` were missing the unique channel name pattern needed to avoid collisions when React re-runs effects before async `removeChannel()` cleanup completes.

## Files changed
- `src/hooks/use-messages.ts` — null guard on channel + removeChannel
- `src/hooks/use-notifications.ts` — null guard + subId for channel name
- `src/hooks/use-presence.ts` — null guard + subId + cleanup flag for track() calls
- `src/hooks/use-typing.ts` — null guard on channel + removeChannel