### PR TITLE
Fix #5 #10: Fix board layout and filter labels

### DIFF
--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/board/board-client.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/board/board-client.tsx
@@ -94,7 +94,7 @@ export function BoardClient({
       {isLoading ? (
         <div className="flex gap-4">
           {statuses.map((s) => (
-            <Skeleton key={s} className="h-96 w-72 shrink-0 rounded-lg" />
+            <Skeleton key={s} className="h-96 min-w-0 flex-1 rounded-lg" />
           ))}
         </div>
       ) : (

--- a/src/components/tasks/filter-bar.tsx
+++ b/src/components/tasks/filter-bar.tsx
@@ -34,50 +34,56 @@ export function FilterBar({
   return (
     <div className="flex items-center gap-2 flex-wrap">
       {/* Status filter */}
-      <Select
-        value={filters.status ?? "all"}
-        onValueChange={(val) =>
-          onFilterChange({
-            ...filters,
-            status: !val || val === "all" ? undefined : val,
-          })
-        }
-      >
-        <SelectTrigger size="sm">
-          <SelectValue placeholder="Status" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All statuses</SelectItem>
-          {statuses.map((s) => (
-            <SelectItem key={s} value={s}>
-              {s}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs font-medium text-muted-foreground">Status:</span>
+        <Select
+          value={filters.status ?? "all"}
+          onValueChange={(val) =>
+            onFilterChange({
+              ...filters,
+              status: !val || val === "all" ? undefined : val,
+            })
+          }
+        >
+          <SelectTrigger size="sm">
+            <SelectValue placeholder="Status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            {statuses.map((s) => (
+              <SelectItem key={s} value={s}>
+                {s}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
 
       {/* Priority filter */}
-      <Select
-        value={filters.priority ?? "all"}
-        onValueChange={(val) =>
-          onFilterChange({
-            ...filters,
-            priority: !val || val === "all" ? undefined : val,
-          })
-        }
-      >
-        <SelectTrigger size="sm">
-          <SelectValue placeholder="Priority" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">All priorities</SelectItem>
-          {TASK_PRIORITIES.map((p) => (
-            <SelectItem key={p} value={p}>
-              <span className="capitalize">{p}</span>
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs font-medium text-muted-foreground">Priority:</span>
+        <Select
+          value={filters.priority ?? "all"}
+          onValueChange={(val) =>
+            onFilterChange({
+              ...filters,
+              priority: !val || val === "all" ? undefined : val,
+            })
+          }
+        >
+          <SelectTrigger size="sm">
+            <SelectValue placeholder="Priority" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All priorities</SelectItem>
+            {TASK_PRIORITIES.map((p) => (
+              <SelectItem key={p} value={p}>
+                <span className="capitalize">{p}</span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
 
       {/* Assignee filter */}
       <Select

--- a/src/components/tasks/task-board.tsx
+++ b/src/components/tasks/task-board.tsx
@@ -47,7 +47,7 @@ function Column({
     <div
       ref={setNodeRef}
       className={cn(
-        "flex h-full w-72 shrink-0 flex-col rounded-lg bg-muted/50",
+        "flex h-full min-w-0 flex-1 flex-col rounded-lg bg-muted/50",
         isOver && "ring-2 ring-primary/30"
       )}
     >


### PR DESCRIPTION
Resolves #5
Resolves #10

## Changes

### BUG-005: Board columns
- Columns used fixed `w-72 shrink-0` (288px non-shrinkable), so 5 columns + gaps = 1504px, overflowing at 1440px
- Changed to `flex-1 min-w-0` so all 5 columns share available space equally
- Also fixed the loading skeleton to match

### BUG-010: Filter labels
- Status and Priority dropdowns had no visible labels — users couldn't tell them apart
- Added `Status:` and `Priority:` label text before each dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)