### PR TITLE
Fix #3: Ensure chat message input visible in channel view

### DIFF
--- a/src/app/(app)/[workspaceSlug]/chat/[channelId]/channel-view.tsx
+++ b/src/app/(app)/[workspaceSlug]/chat/[channelId]/channel-view.tsx
@@ -34,8 +34,8 @@ export function ChannelView({
   }, [openThreadId, messages]);
 
   return (
-    <div className="flex h-full">
-      <div className="flex flex-1 flex-col overflow-hidden">
+    <div className="flex flex-1 min-h-0">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <ChannelHeader channelId={channelId} />
         <MessageList
           channelId={channelId}

--- a/src/app/(app)/[workspaceSlug]/chat/[channelId]/channel-view.tsx
+++ b/src/app/(app)/[workspaceSlug]/chat/[channelId]/channel-view.tsx
@@ -35,7 +35,7 @@ export function ChannelView({
 
   return (
     <div className="flex h-full">
-      <div className="flex flex-1 flex-col">
+      <div className="flex flex-1 flex-col overflow-hidden">
         <ChannelHeader channelId={channelId} />
         <MessageList
           channelId={channelId}

--- a/src/components/chat/message-list.tsx
+++ b/src/components/chat/message-list.tsx
@@ -45,7 +45,7 @@ export function MessageList({ channelId, currentMemberId }: MessageListProps) {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto">
+    <div className="flex-1 min-h-0 overflow-y-auto">
       {messages && messages.length > 0 ? (
         <div className="py-4">
           {messages.map((message) => (


### PR DESCRIPTION
## Summary
- Added `min-h-0` to ChannelView outer container and inner flex column to fix flexbox min-height default preventing proper shrink behavior
- Added `min-h-0` to MessageList scrollable container so the message list shrinks to available space instead of pushing the input offscreen

## Root cause
Flexbox items default to `min-height: auto` (content height). When the message list content is tall, this prevents the flex column from constraining the MessageList, pushing the MessageInput below the visible area where `overflow-hidden` clips it.

## Test plan
- [ ] Navigate to a chat channel — message input textarea should be visible at the bottom
- [ ] Send messages to fill the channel — input remains pinned at bottom, messages scroll
- [ ] Open thread panel and info sidebar — input stays visible in the main column
- [ ] Check empty channel state — input is visible below "No messages yet" placeholder

Resolves #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)