### PR TITLE
Fix #13 #14 #15: Task links, analytics nav, form reset

### DIFF
--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/list/list-client.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/list/list-client.tsx
@@ -303,7 +303,8 @@ export function ListClient({
                       onCheckedChange={() => toggleTask(task.id)}
                     />
                   </span>
-                  <div
+                  <Link
+                    href={`${base}/tasks/${task.identifier}`}
                     className="flex items-center gap-2 min-w-0"
                     onClick={() => setSelectedTaskId(task.id)}
                   >
@@ -317,7 +318,7 @@ export function ListClient({
                       {task.identifier}
                     </span>
                     <span className="truncate font-medium">{task.title}</span>
-                  </div>
+                  </Link>
                   <div onClick={() => setSelectedTaskId(task.id)}>
                     <Badge variant="secondary" className="text-xs">
                       {task.status}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -10,6 +10,7 @@ import {
   BookOpen,
   Users,
   Shield,
+  BarChart3,
   Settings,
   ChevronLeft,
   ChevronRight,
@@ -35,6 +36,7 @@ const navItems = [
 const managementItems = [
   { label: "Members", icon: Users, href: "/members" },
   { label: "Roles", icon: Shield, href: "/roles" },
+  { label: "Analytics", icon: BarChart3, href: "/analytics" },
   { label: "Settings", icon: Settings, href: "/settings" },
 ];
 

--- a/src/components/projects/project-form.tsx
+++ b/src/components/projects/project-form.tsx
@@ -102,7 +102,7 @@ export function ProjectForm({
               id="proj-name"
               value={name}
               onChange={(e) => handleNameChange(e.target.value)}
-              placeholder="API Backend"
+              placeholder="e.g. Marketing Site"
               required
             />
           </div>
@@ -115,7 +115,7 @@ export function ProjectForm({
                 setSlug(slugify(e.target.value));
                 setSlugEdited(true);
               }}
-              placeholder="api-backend"
+              placeholder="e.g. marketing-site"
               required
             />
           </div>


### PR DESCRIPTION
Resolves #13
Resolves #14
Resolves #15

## Changes

### BUG-013: Task list links
- Task name cell now uses Next.js `<Link>` instead of `<div>` with `onClick`
- Right-click → open in new tab now works
- Improved accessibility for screen readers

### BUG-014: Analytics nav
- Added Analytics link to sidebar navigation with `BarChart3` icon
- Placed in management section alongside Members, Roles, Settings

### BUG-015: Project form reset
- Changed placeholder from "API Backend" / "api-backend" to generic examples
- Form no longer appears pre-filled with a specific project name

🤖 Generated with [Claude Code](https://claude.com/claude-code)