### PR TITLE
Fix #4 #8: Fix login redirect and invalid workspace 404

### DIFF
--- a/src/app/(app)/[workspaceSlug]/layout.tsx
+++ b/src/app/(app)/[workspaceSlug]/layout.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { AppShell } from "./app-shell";
 
@@ -25,7 +25,7 @@ export default async function WorkspaceLayout({
     .eq("slug", workspaceSlug)
     .single();
 
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   // Verify membership
   const { data: membership } = await supabase
@@ -36,7 +36,7 @@ export default async function WorkspaceLayout({
     .eq("status", "active")
     .single();
 
-  if (!membership) redirect("/onboarding");
+  if (!membership) notFound();
 
   // Fetch profile
   const { data: profile } = await supabase

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -33,5 +33,5 @@ export async function updateSession(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
-  return { user, supabaseResponse };
+  return { user, supabaseResponse, supabase };
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -25,7 +25,7 @@ export async function middleware(request: NextRequest) {
   }
 
   // Refresh session and get user
-  const { user, supabaseResponse } = await updateSession(request);
+  const { user, supabaseResponse, supabase } = await updateSession(request);
 
   // No valid session — redirect to login
   if (!user) {
@@ -35,10 +35,22 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
-  // Root path — redirect to onboarding or last workspace
+  // Root path — redirect to workspace dashboard or onboarding
   if (pathname === "/") {
+    const { data: memberships } = await supabase
+      .from("workspace_members")
+      .select("workspace:workspaces(slug)")
+      .eq("user_id", user.id)
+      .eq("status", "active")
+      .limit(1);
+
     const url = request.nextUrl.clone();
-    url.pathname = "/onboarding";
+    if (memberships && memberships.length > 0) {
+      const workspace = memberships[0].workspace as unknown as { slug: string };
+      url.pathname = `/${workspace.slug}/dashboard`;
+    } else {
+      url.pathname = "/onboarding";
+    }
     return NextResponse.redirect(url);
   }
 


### PR DESCRIPTION
Resolves #4
Resolves #8

## Changes

### BUG-004: Login redirect
- Middleware now checks workspace memberships when handling the `/` redirect
- Existing workspace members redirect directly to `/{workspaceSlug}/dashboard` after login
- Previously always redirected to `/onboarding`, causing a blank page flash for existing members
- New users (no workspace memberships) still redirect to `/onboarding` as expected

### BUG-008: Invalid workspace 404
- Invalid workspace slugs now show a proper 404 page via `notFound()`
- Non-member access to a workspace also shows 404 (prevents workspace existence disclosure)
- Previously silently redirected to `/onboarding` regardless of the reason

## Files changed
- `src/middleware.ts` — query workspace memberships on `/` redirect
- `src/lib/supabase/middleware.ts` — expose supabase client from `updateSession()`
- `src/app/(app)/[workspaceSlug]/layout.tsx` — use `notFound()` instead of `redirect()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)