### PR TITLE
Fix #6 #7: Command palette and mobile sidebar

### DIFF
--- a/src/app/(app)/[workspaceSlug]/app-shell.tsx
+++ b/src/app/(app)/[workspaceSlug]/app-shell.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useState } from "react";
 import { Sidebar } from "@/components/layout/sidebar";
+import { MobileSidebar } from "@/components/layout/mobile-sidebar";
 import { Header } from "@/components/layout/header";
 import { AIChatPanel } from "@/components/ai/ai-chat-panel";
 import { FloatingAIButton } from "@/components/ai/floating-ai-button";
@@ -25,17 +27,28 @@ export function AppShell({
   userEmail,
   children,
 }: AppShellProps) {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
   return (
     <div className="flex h-screen overflow-hidden">
       <Sidebar workspaceSlug={workspaceSlug} workspaceName={workspaceName} />
-      <div className="flex flex-1 flex-col overflow-hidden">
+      <div className="flex w-full flex-1 flex-col overflow-hidden">
         <Header
           userDisplayName={userDisplayName}
           userAvatarUrl={userAvatarUrl}
           userEmail={userEmail}
+          onMobileMenuToggle={() => setMobileMenuOpen(true)}
         />
         <main className="flex-1 overflow-y-auto p-6">{children}</main>
       </div>
+
+      {/* Mobile sidebar */}
+      <MobileSidebar
+        open={mobileMenuOpen}
+        onOpenChange={setMobileMenuOpen}
+        workspaceSlug={workspaceSlug}
+        workspaceName={workspaceName}
+      />
 
       {/* Global overlays */}
       <CommandPalette workspaceSlug={workspaceSlug} workspaceId={workspaceId} />

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { LogOut, Moon, Sun, User } from "lucide-react";
+import { LogOut, Menu, Moon, Sun, User } from "lucide-react";
 import { NotificationBell } from "./notification-bell";
 import { useTheme } from "next-themes";
 
@@ -19,12 +19,14 @@ interface HeaderProps {
   userDisplayName: string;
   userAvatarUrl?: string | null;
   userEmail: string;
+  onMobileMenuToggle?: () => void;
 }
 
 export function Header({
   userDisplayName,
   userAvatarUrl,
   userEmail,
+  onMobileMenuToggle,
 }: HeaderProps) {
   const router = useRouter();
   const { theme, setTheme } = useTheme();
@@ -46,6 +48,17 @@ export function Header({
   return (
     <header className="flex h-14 items-center justify-between border-b bg-background px-4">
       <div className="flex items-center gap-4">
+        {onMobileMenuToggle && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="md:hidden"
+            onClick={onMobileMenuToggle}
+          >
+            <Menu className="h-5 w-5" />
+            <span className="sr-only">Toggle menu</span>
+          </Button>
+        )}
         {/* Breadcrumbs placeholder */}
         <h2 className="text-sm font-semibold text-foreground">TeamForge</h2>
       </div>

--- a/src/components/layout/mobile-sidebar.tsx
+++ b/src/components/layout/mobile-sidebar.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import {
+  LayoutDashboard,
+  FolderKanban,
+  MessageSquare,
+  BookOpen,
+  Users,
+  Shield,
+  Settings,
+} from "lucide-react";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { WorkspaceSwitcher } from "./workspace-switcher";
+
+interface MobileSidebarProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  workspaceSlug: string;
+  workspaceName: string;
+}
+
+const navItems = [
+  { label: "Dashboard", icon: LayoutDashboard, href: "/dashboard" },
+  { label: "Projects", icon: FolderKanban, href: "/projects" },
+  { label: "Chat", icon: MessageSquare, href: "/chat" },
+  { label: "Wiki", icon: BookOpen, href: "/wiki" },
+];
+
+const managementItems = [
+  { label: "Members", icon: Users, href: "/members" },
+  { label: "Roles", icon: Shield, href: "/roles" },
+  { label: "Settings", icon: Settings, href: "/settings" },
+];
+
+export function MobileSidebar({
+  open,
+  onOpenChange,
+  workspaceSlug,
+  workspaceName,
+}: MobileSidebarProps) {
+  const pathname = usePathname();
+  const base = `/${workspaceSlug}`;
+
+  function navigate() {
+    onOpenChange(false);
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="left" className="w-64 p-0">
+        <SheetHeader className="border-b px-3 py-4">
+          <SheetTitle className="text-sm">
+            <WorkspaceSwitcher
+              currentSlug={workspaceSlug}
+              currentName={workspaceName}
+            />
+          </SheetTitle>
+        </SheetHeader>
+
+        <ScrollArea className="flex-1 py-2">
+          <nav className="space-y-1 px-2">
+            {navItems.map((item) => {
+              const href = `${base}${item.href}`;
+              const isActive =
+                pathname === href || pathname.startsWith(href + "/");
+              return (
+                <Link
+                  key={item.href}
+                  href={href}
+                  onClick={navigate}
+                  className={cn(
+                    "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                    isActive
+                      ? "bg-sidebar-accent text-sidebar-primary"
+                      : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground"
+                  )}
+                >
+                  <item.icon className="h-4 w-4 shrink-0" />
+                  <span>{item.label}</span>
+                </Link>
+              );
+            })}
+          </nav>
+
+          <Separator className="my-3" />
+
+          <nav className="space-y-1 px-2">
+            {managementItems.map((item) => {
+              const href = `${base}${item.href}`;
+              const isActive =
+                pathname === href || pathname.startsWith(href + "/");
+              return (
+                <Link
+                  key={item.href}
+                  href={href}
+                  onClick={navigate}
+                  className={cn(
+                    "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                    isActive
+                      ? "bg-sidebar-accent text-sidebar-primary"
+                      : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground"
+                  )}
+                >
+                  <item.icon className="h-4 w-4 shrink-0" />
+                  <span>{item.label}</span>
+                </Link>
+              );
+            })}
+          </nav>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -47,7 +47,7 @@ export function Sidebar({ workspaceSlug, workspaceName }: SidebarProps) {
   return (
     <aside
       className={cn(
-        "flex h-screen flex-col border-r bg-sidebar text-sidebar-foreground transition-all duration-200",
+        "hidden h-screen flex-col border-r bg-sidebar text-sidebar-foreground transition-all duration-200 md:flex",
         collapsed ? "w-16" : "w-64"
       )}
     >

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -60,7 +60,9 @@ function CommandDialog({
         )}
         showCloseButton={showCloseButton}
       >
-        {children}
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground">
+          {children}
+        </Command>
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
Resolves #6
Resolves #7

## Changes

### BUG-006: Command palette (Ctrl+K)
- `CommandDialog` in `command.tsx` was missing the `<Command>` wrapper around its children — cmdk primitives (`CommandInput`, `CommandList`, etc.) had no context provider, so the palette never rendered when toggled
- Added the `<Command>` wrapper inside `DialogContent` so Ctrl+K / Cmd+K now correctly opens the command palette

### BUG-007: Mobile sidebar overflow
- Desktop sidebar now uses `hidden md:flex` to hide on viewports below `md` (768px), eliminating the 256px overflow on 375px mobile screens
- Added a hamburger menu button in the header (visible only on mobile via `md:hidden`)
- Created `MobileSidebar` component using the shadcn Sheet (slide-over panel from left) with the same navigation items as the desktop sidebar
- Tapping a nav link in the mobile sidebar automatically closes the sheet
- Main content div uses `w-full` to fill available space on mobile

## Test plan
- [ ] Press Ctrl+K (or Cmd+K on Mac) — command palette dialog should open
- [ ] Type a search query — results should appear
- [ ] Select a navigation item — should navigate and close palette
- [ ] Resize browser to 375px width — no horizontal overflow
- [ ] Hamburger menu button visible on mobile, hidden on desktop
- [ ] Tapping hamburger opens slide-over sidebar from left
- [ ] Navigating via mobile sidebar closes the sheet
- [ ] Desktop sidebar still works normally (collapse/expand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)