### PR TITLE
Fix #13 #14 #15: Task links, analytics nav, form reset

### DIFF
--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/list/list-client.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/list/list-client.tsx
@@ -287,27 +287,28 @@ export function ListClient({
               const isSelected = selectedTaskIds.has(task.id);
 
               return (
-                <div
+                <Link
                   key={task.id}
+                  href={`${base}/tasks/${task.identifier}`}
                   className={cn(
-                    "grid cursor-pointer grid-cols-[40px_1fr_120px_120px_100px_100px] items-center gap-2 border-b px-4 py-2.5 text-sm transition-colors hover:bg-muted/30 last:border-0",
+                    "grid grid-cols-[40px_1fr_120px_120px_100px_100px] items-center gap-2 border-b px-4 py-2.5 text-sm transition-colors hover:bg-muted/30 last:border-0",
                     isSelected && "bg-muted/40"
                   )}
                 >
                   <span
                     className="flex items-center justify-center"
-                    onClick={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      toggleTask(task.id);
+                    }}
                   >
                     <Checkbox
                       checked={isSelected}
                       onCheckedChange={() => toggleTask(task.id)}
                     />
                   </span>
-                  <Link
-                    href={`${base}/tasks/${task.identifier}`}
-                    className="flex items-center gap-2 min-w-0"
-                    onClick={() => setSelectedTaskId(task.id)}
-                  >
+                  <span className="flex items-center gap-2 min-w-0">
                     <span
                       className={cn(
                         "h-2 w-2 shrink-0 rounded-full",
@@ -318,18 +319,18 @@ export function ListClient({
                       {task.identifier}
                     </span>
                     <span className="truncate font-medium">{task.title}</span>
-                  </Link>
-                  <div onClick={() => setSelectedTaskId(task.id)}>
+                  </span>
+                  <div>
                     <Badge variant="secondary" className="text-xs">
                       {task.status}
                     </Badge>
                   </div>
-                  <div onClick={() => setSelectedTaskId(task.id)}>
+                  <div>
                     <Badge variant="outline" className="text-xs capitalize">
                       {task.priority}
                     </Badge>
                   </div>
-                  <div onClick={() => setSelectedTaskId(task.id)}>
+                  <div>
                     {assigneeName ? (
                       <Avatar className="h-6 w-6">
                         <AvatarFallback className="text-[10px]">
@@ -340,7 +341,7 @@ export function ListClient({
                       <span className="text-xs text-muted-foreground">--</span>
                     )}
                   </div>
-                  <div onClick={() => setSelectedTaskId(task.id)}>
+                  <div>
                     {task.due_date ? (
                       <span
                         className={cn(
@@ -360,7 +361,7 @@ export function ListClient({
                       <span className="text-xs text-muted-foreground">--</span>
                     )}
                   </div>
-                </div>
+                </Link>
               );
             })
           ) : (

--- a/src/components/projects/project-form.tsx
+++ b/src/components/projects/project-form.tsx
@@ -86,7 +86,17 @@ export function ProjectForm({
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={(newOpen) => {
+      setOpen(newOpen);
+      if (newOpen) {
+        setName("");
+        setSlug("");
+        setSlugEdited(false);
+        setDescription("");
+        setPriority("medium");
+        setError(null);
+      }
+    }}>
       <DialogTrigger className="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow hover:bg-primary/90">
         <Plus className="h-4 w-4" />
         New Project


### PR DESCRIPTION
Resolves #13
Resolves #14
Resolves #15

## Changes
- **Task rows now use `<Link>` for accessible navigation** — replaced `<div>` + `onClick` handlers with a single `<Link>` wrapping each task row in list view. Checkbox click prevents navigation via `e.preventDefault()`.
- **Analytics already present in sidebar** — verified the Analytics nav item with `BarChart3` icon exists in `managementItems` at `/analytics`.
- **Create project form resets on open** — `onOpenChange` now clears name, slug, description, priority, and error state when the dialog opens, preventing stale values like "API Backend" from persisting.

## Test plan
- [ ] Open task list view — verify rows are proper `<a>` links (right-click → open in new tab should work)
- [ ] Click a task row — verify it navigates to the task detail page
- [ ] Click the checkbox on a task row — verify it toggles selection without navigating
- [ ] Open sidebar — verify Analytics link is present and navigates to `/analytics`
- [ ] Open "New Project" dialog, type a name, close dialog without submitting, reopen — verify fields are empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)