### PR TITLE
Fix #6 #7: Command palette and responsive mobile sidebar

### DIFF
--- a/src/app/(app)/[workspaceSlug]/app-shell.tsx
+++ b/src/app/(app)/[workspaceSlug]/app-shell.tsx
@@ -31,7 +31,10 @@ export function AppShell({
 
   return (
     <div className="flex h-screen overflow-hidden">
-      <Sidebar workspaceSlug={workspaceSlug} workspaceName={workspaceName} />
+      {/* Desktop sidebar - hidden on mobile */}
+      <div className="hidden md:flex">
+        <Sidebar workspaceSlug={workspaceSlug} workspaceName={workspaceName} />
+      </div>
       <div className="flex w-full flex-1 flex-col overflow-hidden">
         <Header
           userDisplayName={userDisplayName}

--- a/src/components/layout/mobile-sidebar.tsx
+++ b/src/components/layout/mobile-sidebar.tsx
@@ -1,26 +1,8 @@
 "use client";
 
-import Link from "next/link";
+import { useEffect } from "react";
 import { usePathname } from "next/navigation";
-import { cn } from "@/lib/utils";
-import {
-  LayoutDashboard,
-  FolderKanban,
-  MessageSquare,
-  BookOpen,
-  Users,
-  Shield,
-  Settings,
-} from "lucide-react";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Separator } from "@/components/ui/separator";
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
-import { WorkspaceSwitcher } from "./workspace-switcher";
+import { Sidebar } from "./sidebar";
 
 interface MobileSidebarProps {
   open: boolean;
@@ -29,19 +11,6 @@ interface MobileSidebarProps {
   workspaceName: string;
 }
 
-const navItems = [
-  { label: "Dashboard", icon: LayoutDashboard, href: "/dashboard" },
-  { label: "Projects", icon: FolderKanban, href: "/projects" },
-  { label: "Chat", icon: MessageSquare, href: "/chat" },
-  { label: "Wiki", icon: BookOpen, href: "/wiki" },
-];
-
-const managementItems = [
-  { label: "Members", icon: Users, href: "/members" },
-  { label: "Roles", icon: Shield, href: "/roles" },
-  { label: "Settings", icon: Settings, href: "/settings" },
-];
-
 export function MobileSidebar({
   open,
   onOpenChange,
@@ -49,76 +18,36 @@ export function MobileSidebar({
   workspaceName,
 }: MobileSidebarProps) {
   const pathname = usePathname();
-  const base = `/${workspaceSlug}`;
 
-  function navigate() {
+  // Close on navigation
+  useEffect(() => {
     onOpenChange(false);
-  }
+  }, [pathname, onOpenChange]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onOpenChange(false);
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open, onOpenChange]);
+
+  if (!open) return null;
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="left" className="w-64 p-0">
-        <SheetHeader className="border-b px-3 py-4">
-          <SheetTitle className="text-sm">
-            <WorkspaceSwitcher
-              currentSlug={workspaceSlug}
-              currentName={workspaceName}
-            />
-          </SheetTitle>
-        </SheetHeader>
-
-        <ScrollArea className="flex-1 py-2">
-          <nav className="space-y-1 px-2">
-            {navItems.map((item) => {
-              const href = `${base}${item.href}`;
-              const isActive =
-                pathname === href || pathname.startsWith(href + "/");
-              return (
-                <Link
-                  key={item.href}
-                  href={href}
-                  onClick={navigate}
-                  className={cn(
-                    "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                    isActive
-                      ? "bg-sidebar-accent text-sidebar-primary"
-                      : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground"
-                  )}
-                >
-                  <item.icon className="h-4 w-4 shrink-0" />
-                  <span>{item.label}</span>
-                </Link>
-              );
-            })}
-          </nav>
-
-          <Separator className="my-3" />
-
-          <nav className="space-y-1 px-2">
-            {managementItems.map((item) => {
-              const href = `${base}${item.href}`;
-              const isActive =
-                pathname === href || pathname.startsWith(href + "/");
-              return (
-                <Link
-                  key={item.href}
-                  href={href}
-                  onClick={navigate}
-                  className={cn(
-                    "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                    isActive
-                      ? "bg-sidebar-accent text-sidebar-primary"
-                      : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground"
-                  )}
-                >
-                  <item.icon className="h-4 w-4 shrink-0" />
-                  <span>{item.label}</span>
-                </Link>
-              );
-            })}
-          </nav>
-        </ScrollArea>
-      </SheetContent>
-    </Sheet>
+    <div className="fixed inset-0 z-40 md:hidden">
+      <div
+        className="fixed inset-0 bg-black/50"
+        onClick={() => onOpenChange(false)}
+      />
+      <div
+        className="relative z-50 h-full animate-in slide-in-from-left duration-200"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Sidebar workspaceSlug={workspaceSlug} workspaceName={workspaceName} />
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
Resolves #6
Resolves #7

## Changes

### BUG-006: Command palette (Ctrl+K) does not open
- Added missing `<Command>` wrapper inside `CommandDialog` — without it, cmdk sub-components (`CommandInput`, `CommandList`) couldn't find their context provider and failed at runtime

### BUG-007: Horizontal overflow on mobile — sidebar not collapsible
- Desktop sidebar wrapped in `hidden md:flex` so it's hidden on mobile viewports
- Added hamburger menu button in the header, visible only on mobile (`md:hidden`)
- Created `MobileSidebar` overlay component that renders the existing `Sidebar` with a backdrop
- Mobile sidebar closes on navigation, Escape key, or backdrop click
- Main content area takes full width on mobile

## Test plan
- [ ] Press Ctrl+K (or Cmd+K on Mac) — command palette should open with search and navigation items
- [ ] Resize browser to 375px width — sidebar should be hidden, hamburger button visible
- [ ] Tap hamburger — sidebar overlay should slide in from the left
- [ ] Tap a nav item in mobile sidebar — sidebar should close, page should navigate
- [ ] Press Escape while mobile sidebar is open — should close
- [ ] Tap backdrop while mobile sidebar is open — should close
- [ ] At desktop width (≥768px) — sidebar should display normally, no hamburger button

🤖 Generated with [Claude Code](https://claude.com/claude-code)