### PR TITLE
Fix #4 #8: Fix login redirect and invalid workspace 404

### DIFF
--- a/src/app/(app)/[workspaceSlug]/analytics/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/analytics/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { AnalyticsClient } from "./analytics-client";
 
@@ -20,7 +20,7 @@ export default async function AnalyticsPage({
     .select("id")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   return <AnalyticsClient workspaceId={workspace.id} />;
 }

--- a/src/app/(app)/[workspaceSlug]/chat/[channelId]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/chat/[channelId]/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { ChannelView } from "./channel-view";
 
@@ -20,7 +20,7 @@ export default async function ChannelPage({
     .select("id")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: member } = await supabase
     .from("workspace_members")
@@ -28,7 +28,7 @@ export default async function ChannelPage({
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
     .single();
-  if (!member) redirect("/onboarding");
+  if (!member) notFound();
 
   // Auto-join public/project channels
   const { data: channel, error: channelError } = await supabase

--- a/src/app/(app)/[workspaceSlug]/chat/layout.tsx
+++ b/src/app/(app)/[workspaceSlug]/chat/layout.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { ChatLayoutClient } from "./chat-layout-client";
 
@@ -20,7 +20,7 @@ export default async function ChatLayout({
     .select("id")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: member } = await supabase
     .from("workspace_members")
@@ -28,7 +28,7 @@ export default async function ChatLayout({
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
     .single();
-  if (!member) redirect("/onboarding");
+  if (!member) notFound();
 
   return (
     <ChatLayoutClient

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/board/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/board/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { BoardClient } from "./board-client";
 
@@ -22,7 +22,7 @@ export default async function BoardPage({
     .select("id")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: project } = await supabase
     .from("projects")

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/bugs/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/bugs/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { BugsClient } from "./bugs-client";
 
@@ -20,7 +20,7 @@ export default async function BugsPage({
     .select("id")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: project } = await supabase
     .from("projects")

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/calendar/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/calendar/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { CalendarPageClient } from "./calendar-client";
 
@@ -20,7 +20,7 @@ export default async function CalendarPage({
     .select("id")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: project } = await supabase
     .from("projects")

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/docs/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/docs/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { ProjectDocsClient } from "./project-docs-client";
 
@@ -20,7 +20,7 @@ export default async function ProjectDocsPage({
     .select("id")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: project } = await supabase
     .from("projects")

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/list/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/list/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { ListClient } from "./list-client";
 
@@ -22,7 +22,7 @@ export default async function ListPage({
     .select("id")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: project } = await supabase
     .from("projects")

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { ProjectDetailClient } from "./project-detail-client";
 
@@ -29,7 +29,7 @@ export default async function ProjectDetailPage({
     .select("id")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: project } = await supabase
     .from("projects")

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/scans/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/scans/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { ScansClient } from "./scans-client";
 
@@ -20,7 +20,7 @@ export default async function ScansPage({
     .select("id")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: project } = await supabase
     .from("projects")

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/settings/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/settings/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { ProjectSettingsClient } from "./project-settings-client";
 
@@ -22,7 +22,7 @@ export default async function ProjectSettingsPage({
     .select("id")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: project } = await supabase
     .from("projects")

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/tasks/[taskIdentifier]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/tasks/[taskIdentifier]/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { TaskDetailPage } from "./task-detail-page";
 
@@ -26,7 +26,7 @@ export default async function TaskPage({
     .select("id")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: project } = await supabase
     .from("projects")

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/timeline/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/timeline/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { TimelinePageClient } from "./timeline-client";
 
@@ -20,7 +20,7 @@ export default async function TimelinePage({
     .select("id")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: project } = await supabase
     .from("projects")

--- a/src/app/(app)/[workspaceSlug]/settings/ai/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/ai/page.tsx
@@ -1,5 +1,5 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { AiSettingsClient } from "./ai-settings-client";
 
 export const metadata = { title: "AI Settings - TeamForge" };
@@ -22,7 +22,7 @@ export default async function AiSettingsPage({
     .select("*")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: member } = await supabase
     .from("workspace_members")

--- a/src/app/(app)/[workspaceSlug]/settings/api-keys/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/api-keys/page.tsx
@@ -1,5 +1,5 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { ApiKeysClient } from "./api-keys-client";
 
 export const metadata = { title: "API Keys - TeamForge" };
@@ -22,7 +22,7 @@ export default async function ApiKeysPage({
     .select("*")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: member } = await supabase
     .from("workspace_members")

--- a/src/app/(app)/[workspaceSlug]/settings/integrations/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/integrations/page.tsx
@@ -1,5 +1,5 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { IntegrationsClient } from "./integrations-client";
 
 export const metadata = { title: "Integrations - TeamForge" };
@@ -22,7 +22,7 @@ export default async function IntegrationsPage({
     .select("*")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: member } = await supabase
     .from("workspace_members")

--- a/src/app/(app)/[workspaceSlug]/settings/notifications/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/notifications/page.tsx
@@ -1,5 +1,5 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { NotificationsClient } from "./notifications-client";
 
 export const metadata = { title: "Notification Preferences - TeamForge" };
@@ -22,7 +22,7 @@ export default async function NotificationsPage({
     .select("*")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   return (
     <NotificationsClient

--- a/src/app/(app)/[workspaceSlug]/settings/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/page.tsx
@@ -1,5 +1,5 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { SettingsClient } from "./settings-client";
 
 export const metadata = { title: "Settings - TeamForge" };
@@ -22,7 +22,7 @@ export default async function SettingsPage({
     .select("*")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const isOwner = workspace.owner_id === user.id;
 

--- a/src/app/(app)/[workspaceSlug]/wiki/[pageId]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/wiki/[pageId]/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { WikiPageView } from "./wiki-page-view";
 
@@ -20,7 +20,7 @@ export default async function WikiPagePage({
     .select("id")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: member } = await supabase
     .from("workspace_members")
@@ -28,7 +28,7 @@ export default async function WikiPagePage({
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
     .single();
-  if (!member) redirect("/onboarding");
+  if (!member) notFound();
 
   return (
     <WikiPageView

--- a/src/app/(app)/[workspaceSlug]/wiki/layout.tsx
+++ b/src/app/(app)/[workspaceSlug]/wiki/layout.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { WikiLayoutClient } from "./wiki-layout-client";
 
@@ -20,7 +20,7 @@ export default async function WikiLayout({
     .select("id")
     .eq("slug", workspaceSlug)
     .single();
-  if (!workspace) redirect("/onboarding");
+  if (!workspace) notFound();
 
   const { data: member } = await supabase
     .from("workspace_members")
@@ -28,7 +28,7 @@ export default async function WikiLayout({
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
     .single();
-  if (!member) redirect("/onboarding");
+  if (!member) notFound();
 
   return (
     <WikiLayoutClient

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -35,8 +35,8 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
-  // Root path — redirect to workspace dashboard or onboarding
-  if (pathname === "/") {
+  // Root path or onboarding — redirect to workspace dashboard if user has memberships
+  if (pathname === "/" || pathname === "/onboarding") {
     const { data: memberships } = await supabase
       .from("workspace_members")
       .select("workspace:workspaces(slug)")
@@ -44,14 +44,21 @@ export async function middleware(request: NextRequest) {
       .eq("status", "active")
       .limit(1);
 
-    const url = request.nextUrl.clone();
     if (memberships && memberships.length > 0) {
       const workspace = memberships[0].workspace as unknown as { slug: string };
+      const url = request.nextUrl.clone();
       url.pathname = `/${workspace.slug}/dashboard`;
-    } else {
-      url.pathname = "/onboarding";
+      return NextResponse.redirect(url);
     }
-    return NextResponse.redirect(url);
+
+    // No workspaces — let /onboarding render, redirect / to /onboarding
+    if (pathname === "/") {
+      const url = request.nextUrl.clone();
+      url.pathname = "/onboarding";
+      return NextResponse.redirect(url);
+    }
+
+    return supabaseResponse;
   }
 
   return supabaseResponse;


### PR DESCRIPTION
Resolves #4
Resolves #8

## Changes
- **BUG-004**: Middleware now intercepts `/onboarding` in addition to `/` — users with existing workspace memberships are redirected to their dashboard before the onboarding page renders, preventing the blank page
- **BUG-008**: Changed all `redirect("/onboarding")` calls in workspace sub-routes to `notFound()` — invalid workspace slugs now return a proper 404 instead of silently redirecting through `/onboarding` to the user's real workspace

## Root causes
- **#4**: The middleware only checked memberships for the `/` path. If a user with workspaces reached `/onboarding` (e.g., timing issue during session setup), they saw a blank page
- **#8**: 20 sub-routes under `[workspaceSlug]` used `redirect("/onboarding")` for workspace validation. Since Next.js renders layouts and pages concurrently, these redirects could race with the layout's `notFound()`, causing: invalid slug → redirect to `/onboarding` → onboarding detects membership → redirect to real workspace

## Test plan
- [ ] Log in with existing workspace — should land on `/{slug}/dashboard`, not `/onboarding`
- [ ] Visit `/nonexistent-slug/dashboard` while authenticated — should see 404
- [ ] Visit `/nonexistent-slug/chat` while authenticated — should see 404
- [ ] Visit `/onboarding` with existing workspace — should redirect to dashboard
- [ ] Visit `/onboarding` without any workspace — should see onboarding form
- [ ] New user signup flow still works (no workspace → onboarding → create workspace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)