### PR TITLE
Fix #9 #11 #12: Analytics data, script tag, 406 errors

### DIFF
--- a/src/app/(app)/[workspaceSlug]/analytics/analytics-client.tsx
+++ b/src/app/(app)/[workspaceSlug]/analytics/analytics-client.tsx
@@ -21,20 +21,25 @@ export function AnalyticsClient({ workspaceId }: AnalyticsClientProps) {
   const { data: stats, isLoading } = useQuery({
     queryKey: ["workspace-analytics", workspaceId],
     queryFn: async () => {
-      const [projects, tasks, completedTasks, bugs, members] =
+      const [projects, tasks, bugs, members] =
         await Promise.all([
-          supabase.from("projects").select("id, name, slug, status, priority", { count: "exact" }).eq("workspace_id", workspaceId).neq("status", "archived"),
+          supabase.from("projects").select("id, name, slug, status, priority, settings", { count: "exact" }).eq("workspace_id", workspaceId).neq("status", "archived"),
           supabase.from("tasks").select("*", { count: "exact", head: true }).eq("workspace_id", workspaceId),
-          supabase.from("tasks").select("*", { count: "exact", head: true }).eq("workspace_id", workspaceId).not("completed_at", "is", null),
           supabase.from("bugs").select("*", { count: "exact", head: true }).eq("workspace_id", workspaceId).in("status", ["open", "confirmed", "in_progress"]),
           supabase.from("workspace_members").select("id, display_name", { count: "exact" }).eq("workspace_id", workspaceId).eq("status", "active"),
         ]);
 
-      // Per-project task counts
+      // Per-project task counts — use each project's final status as "done"
+      const defaultStatuses = ["Backlog", "Todo", "In Progress", "Review", "Done"];
       const projectStats = [];
+      let totalCompleted = 0;
       for (const proj of projects.data ?? []) {
+        const statuses = (proj.settings as Record<string, unknown>)?.statuses as string[] ?? defaultStatuses;
+        const doneStatus = statuses[statuses.length - 1];
+
         const { count: total } = await supabase.from("tasks").select("*", { count: "exact", head: true }).eq("project_id", proj.id);
-        const { count: done } = await supabase.from("tasks").select("*", { count: "exact", head: true }).eq("project_id", proj.id).not("completed_at", "is", null);
+        const { count: done } = await supabase.from("tasks").select("*", { count: "exact", head: true }).eq("project_id", proj.id).eq("status", doneStatus);
+        totalCompleted += done ?? 0;
         projectStats.push({
           ...proj,
           totalTasks: total ?? 0,
@@ -46,13 +51,13 @@ export function AnalyticsClient({ workspaceId }: AnalyticsClientProps) {
       return {
         totalProjects: projects.count ?? 0,
         totalTasks: tasks.count ?? 0,
-        completedTasks: completedTasks.count ?? 0,
+        completedTasks: totalCompleted,
         openBugs: bugs.count ?? 0,
         totalMembers: members.count ?? 0,
         projects: projectStats,
         overallCompletion:
           (tasks.count ?? 0) > 0
-            ? Math.round(((completedTasks.count ?? 0) / (tasks.count ?? 1)) * 100)
+            ? Math.round((totalCompleted / (tasks.count ?? 1)) * 100)
             : 0,
       };
     },
@@ -64,12 +69,13 @@ export function AnalyticsClient({ workspaceId }: AnalyticsClientProps) {
     queryFn: async () => {
       const { data: allTasks } = await supabase
         .from("tasks")
-        .select("assignee_id, completed_at, assignee:workspace_members!tasks_assignee_id_fkey(display_name)")
+        .select("assignee_id, status, project:projects!tasks_project_id_fkey(settings), assignee:workspace_members!tasks_assignee_id_fkey(display_name)")
         .eq("workspace_id", workspaceId)
         .not("assignee_id", "is", null);
 
       if (!allTasks || allTasks.length === 0) return [];
 
+      const defaultStatuses = ["Backlog", "Todo", "In Progress", "Review", "Done"];
       const memberMap = new Map<
         string,
         { name: string; completed: number; open: number }
@@ -80,13 +86,17 @@ export function AnalyticsClient({ workspaceId }: AnalyticsClientProps) {
         const name =
           (task.assignee as { display_name: string | null } | null)
             ?.display_name ?? "Unassigned";
+        const statuses = (task.project as Record<string, unknown>)?.settings
+          ? ((task.project as Record<string, unknown>).settings as Record<string, unknown>)?.statuses as string[] ?? defaultStatuses
+          : defaultStatuses;
+        const doneStatus = statuses[statuses.length - 1];
 
         if (!memberMap.has(memberId)) {
           memberMap.set(memberId, { name, completed: 0, open: 0 });
         }
 
         const entry = memberMap.get(memberId)!;
-        if (task.completed_at) {
+        if (task.status === doneStatus) {
           entry.completed += 1;
         } else {
           entry.open += 1;

--- a/src/app/(app)/[workspaceSlug]/analytics/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/analytics/page.tsx
@@ -19,7 +19,7 @@ export default async function AnalyticsPage({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   return <AnalyticsClient workspaceId={workspace.id} />;

--- a/src/app/(app)/[workspaceSlug]/chat/[channelId]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/chat/[channelId]/page.tsx
@@ -19,7 +19,7 @@ export default async function ChannelPage({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: member } = await supabase
@@ -27,7 +27,7 @@ export default async function ChannelPage({
     .select("id, display_name")
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
-    .single();
+    .maybeSingle();
   if (!member) redirect("/onboarding");
 
   // Auto-join public/project channels
@@ -35,7 +35,7 @@ export default async function ChannelPage({
     .from("channels")
     .select("type")
     .eq("id", channelId)
-    .single();
+    .maybeSingle();
 
   if (channelError) {
     console.error("Channel fetch error:", channelError);

--- a/src/app/(app)/[workspaceSlug]/chat/layout.tsx
+++ b/src/app/(app)/[workspaceSlug]/chat/layout.tsx
@@ -19,7 +19,7 @@ export default async function ChatLayout({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: member } = await supabase
@@ -27,7 +27,7 @@ export default async function ChatLayout({
     .select("id, display_name")
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
-    .single();
+    .maybeSingle();
   if (!member) redirect("/onboarding");
 
   return (

--- a/src/app/(app)/[workspaceSlug]/dashboard/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/dashboard/page.tsx
@@ -19,20 +19,20 @@ export default async function DashboardPage({
     .from("profiles")
     .select("display_name")
     .eq("id", user!.id)
-    .single();
+    .maybeSingle();
 
   const { data: workspace } = await supabase
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
 
   const { data: member } = await supabase
     .from("workspace_members")
     .select("id")
     .eq("workspace_id", workspace!.id)
     .eq("user_id", user!.id)
-    .single();
+    .maybeSingle();
 
   return (
     <DashboardClient

--- a/src/app/(app)/[workspaceSlug]/layout.tsx
+++ b/src/app/(app)/[workspaceSlug]/layout.tsx
@@ -23,7 +23,7 @@ export default async function WorkspaceLayout({
     .from("workspaces")
     .select("*")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
 
   if (!workspace) redirect("/onboarding");
 
@@ -34,7 +34,7 @@ export default async function WorkspaceLayout({
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
     .eq("status", "active")
-    .single();
+    .maybeSingle();
 
   if (!membership) redirect("/onboarding");
 
@@ -43,7 +43,7 @@ export default async function WorkspaceLayout({
     .from("profiles")
     .select("*")
     .eq("id", user.id)
-    .single();
+    .maybeSingle();
 
   return (
     <AppShell

--- a/src/app/(app)/[workspaceSlug]/members/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/members/page.tsx
@@ -19,14 +19,14 @@ export default async function MembersPage({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
 
   const { data: currentMember } = await supabase
     .from("workspace_members")
     .select("id, role:roles(permissions)")
     .eq("workspace_id", workspace!.id)
     .eq("user_id", user!.id)
-    .single();
+    .maybeSingle();
 
   return (
     <MembersClient

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/board/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/board/page.tsx
@@ -21,7 +21,7 @@ export default async function BoardPage({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: project } = await supabase
@@ -29,7 +29,7 @@ export default async function BoardPage({
     .select("id, name, slug, settings")
     .eq("workspace_id", workspace.id)
     .eq("slug", projectSlug)
-    .single();
+    .maybeSingle();
   if (!project) redirect(`/${workspaceSlug}/projects`);
 
   const { data: member } = await supabase
@@ -37,7 +37,7 @@ export default async function BoardPage({
     .select("id")
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
-    .single();
+    .maybeSingle();
 
   const settings = project.settings as { statuses?: string[] } | null;
   const statuses = settings?.statuses ?? [

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/bugs/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/bugs/page.tsx
@@ -19,7 +19,7 @@ export default async function BugsPage({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: project } = await supabase
@@ -27,7 +27,7 @@ export default async function BugsPage({
     .select("id, name, slug")
     .eq("workspace_id", workspace.id)
     .eq("slug", projectSlug)
-    .single();
+    .maybeSingle();
   if (!project) redirect(`/${workspaceSlug}/projects`);
 
   const { data: member } = await supabase
@@ -35,7 +35,7 @@ export default async function BugsPage({
     .select("id")
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
-    .single();
+    .maybeSingle();
 
   return (
     <BugsClient

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/calendar/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/calendar/page.tsx
@@ -19,7 +19,7 @@ export default async function CalendarPage({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: project } = await supabase
@@ -27,7 +27,7 @@ export default async function CalendarPage({
     .select("id, name, slug")
     .eq("workspace_id", workspace.id)
     .eq("slug", projectSlug)
-    .single();
+    .maybeSingle();
   if (!project) redirect(`/${workspaceSlug}/projects`);
 
   return (

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/docs/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/docs/page.tsx
@@ -19,7 +19,7 @@ export default async function ProjectDocsPage({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: project } = await supabase
@@ -27,7 +27,7 @@ export default async function ProjectDocsPage({
     .select("id, name, slug")
     .eq("workspace_id", workspace.id)
     .eq("slug", projectSlug)
-    .single();
+    .maybeSingle();
   if (!project) redirect(`/${workspaceSlug}/projects`);
 
   const { data: member } = await supabase
@@ -35,7 +35,7 @@ export default async function ProjectDocsPage({
     .select("id")
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
-    .single();
+    .maybeSingle();
 
   return (
     <ProjectDocsClient

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/list/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/list/page.tsx
@@ -21,7 +21,7 @@ export default async function ListPage({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: project } = await supabase
@@ -29,7 +29,7 @@ export default async function ListPage({
     .select("id, name, slug, settings")
     .eq("workspace_id", workspace.id)
     .eq("slug", projectSlug)
-    .single();
+    .maybeSingle();
   if (!project) redirect(`/${workspaceSlug}/projects`);
 
   const { data: member } = await supabase
@@ -37,7 +37,7 @@ export default async function ListPage({
     .select("id")
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
-    .single();
+    .maybeSingle();
 
   const settings = project.settings as { statuses?: string[] } | null;
   const statuses = settings?.statuses ?? ["Backlog", "Todo", "In Progress", "Review", "Done"];

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/page.tsx
@@ -28,7 +28,7 @@ export default async function ProjectDetailPage({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: project } = await supabase
@@ -36,7 +36,7 @@ export default async function ProjectDetailPage({
     .select("*")
     .eq("workspace_id", workspace.id)
     .eq("slug", projectSlug)
-    .single();
+    .maybeSingle();
   if (!project) redirect(`/${workspaceSlug}/projects`);
 
   const { data: member } = await supabase
@@ -44,7 +44,7 @@ export default async function ProjectDetailPage({
     .select("id")
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
-    .single();
+    .maybeSingle();
 
   return (
     <ProjectDetailClient

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/scans/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/scans/page.tsx
@@ -19,7 +19,7 @@ export default async function ScansPage({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: project } = await supabase
@@ -27,7 +27,7 @@ export default async function ScansPage({
     .select("id, name, slug, github_repo_url")
     .eq("workspace_id", workspace.id)
     .eq("slug", projectSlug)
-    .single();
+    .maybeSingle();
   if (!project) redirect(`/${workspaceSlug}/projects`);
 
   const { data: member } = await supabase
@@ -35,7 +35,7 @@ export default async function ScansPage({
     .select("id")
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
-    .single();
+    .maybeSingle();
 
   return (
     <ScansClient

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/settings/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/settings/page.tsx
@@ -21,7 +21,7 @@ export default async function ProjectSettingsPage({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: project } = await supabase
@@ -29,7 +29,7 @@ export default async function ProjectSettingsPage({
     .select("*")
     .eq("workspace_id", workspace.id)
     .eq("slug", projectSlug)
-    .single();
+    .maybeSingle();
   if (!project) redirect(`/${workspaceSlug}/projects`);
 
   const { data: member } = await supabase
@@ -37,7 +37,7 @@ export default async function ProjectSettingsPage({
     .select("id")
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
-    .single();
+    .maybeSingle();
 
   return (
     <ProjectSettingsClient

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/tasks/[taskIdentifier]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/tasks/[taskIdentifier]/page.tsx
@@ -25,7 +25,7 @@ export default async function TaskPage({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: project } = await supabase
@@ -33,7 +33,7 @@ export default async function TaskPage({
     .select("id, name, slug, settings")
     .eq("workspace_id", workspace.id)
     .eq("slug", projectSlug)
-    .single();
+    .maybeSingle();
   if (!project) redirect(`/${workspaceSlug}/projects`);
 
   const { data: task } = await supabase
@@ -43,7 +43,7 @@ export default async function TaskPage({
     )
     .eq("project_id", project.id)
     .eq("identifier", taskIdentifier)
-    .single();
+    .maybeSingle();
 
   if (!task) redirect(`/${workspaceSlug}/projects/${projectSlug}/board`);
 
@@ -52,7 +52,7 @@ export default async function TaskPage({
     .select("id")
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
-    .single();
+    .maybeSingle();
 
   const settings = project.settings as { statuses?: string[] } | null;
   const statuses = settings?.statuses ?? [

--- a/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/timeline/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/[projectSlug]/timeline/page.tsx
@@ -19,7 +19,7 @@ export default async function TimelinePage({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: project } = await supabase
@@ -27,7 +27,7 @@ export default async function TimelinePage({
     .select("id, name, slug")
     .eq("workspace_id", workspace.id)
     .eq("slug", projectSlug)
-    .single();
+    .maybeSingle();
   if (!project) redirect(`/${workspaceSlug}/projects`);
 
   return (

--- a/src/app/(app)/[workspaceSlug]/projects/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/projects/page.tsx
@@ -19,14 +19,14 @@ export default async function ProjectsPage({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
 
   const { data: member } = await supabase
     .from("workspace_members")
     .select("id")
     .eq("workspace_id", workspace!.id)
     .eq("user_id", user!.id)
-    .single();
+    .maybeSingle();
 
   return (
     <ProjectsClient

--- a/src/app/(app)/[workspaceSlug]/roles/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/roles/page.tsx
@@ -19,14 +19,14 @@ export default async function RolesPage({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
 
   const { data: currentMember } = await supabase
     .from("workspace_members")
     .select("id, role:roles(permissions)")
     .eq("workspace_id", workspace!.id)
     .eq("user_id", user!.id)
-    .single();
+    .maybeSingle();
 
   return (
     <RolesClient

--- a/src/app/(app)/[workspaceSlug]/settings/ai/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/ai/page.tsx
@@ -21,7 +21,7 @@ export default async function AiSettingsPage({
     .from("workspaces")
     .select("*")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: member } = await supabase
@@ -30,7 +30,7 @@ export default async function AiSettingsPage({
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
     .eq("status", "active")
-    .single();
+    .maybeSingle();
 
   return (
     <AiSettingsClient

--- a/src/app/(app)/[workspaceSlug]/settings/api-keys/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/api-keys/page.tsx
@@ -21,7 +21,7 @@ export default async function ApiKeysPage({
     .from("workspaces")
     .select("*")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: member } = await supabase
@@ -30,7 +30,7 @@ export default async function ApiKeysPage({
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
     .eq("status", "active")
-    .single();
+    .maybeSingle();
 
   return (
     <ApiKeysClient

--- a/src/app/(app)/[workspaceSlug]/settings/integrations/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/integrations/page.tsx
@@ -21,7 +21,7 @@ export default async function IntegrationsPage({
     .from("workspaces")
     .select("*")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: member } = await supabase
@@ -30,7 +30,7 @@ export default async function IntegrationsPage({
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
     .eq("status", "active")
-    .single();
+    .maybeSingle();
 
   return (
     <IntegrationsClient

--- a/src/app/(app)/[workspaceSlug]/settings/notifications/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/notifications/page.tsx
@@ -21,7 +21,7 @@ export default async function NotificationsPage({
     .from("workspaces")
     .select("*")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   return (

--- a/src/app/(app)/[workspaceSlug]/settings/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/page.tsx
@@ -21,7 +21,7 @@ export default async function SettingsPage({
     .from("workspaces")
     .select("*")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const isOwner = workspace.owner_id === user.id;

--- a/src/app/(app)/[workspaceSlug]/wiki/[pageId]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/wiki/[pageId]/page.tsx
@@ -19,7 +19,7 @@ export default async function WikiPagePage({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: member } = await supabase
@@ -27,7 +27,7 @@ export default async function WikiPagePage({
     .select("id")
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
-    .single();
+    .maybeSingle();
   if (!member) redirect("/onboarding");
 
   return (

--- a/src/app/(app)/[workspaceSlug]/wiki/layout.tsx
+++ b/src/app/(app)/[workspaceSlug]/wiki/layout.tsx
@@ -19,7 +19,7 @@ export default async function WikiLayout({
     .from("workspaces")
     .select("id")
     .eq("slug", workspaceSlug)
-    .single();
+    .maybeSingle();
   if (!workspace) redirect("/onboarding");
 
   const { data: member } = await supabase
@@ -27,7 +27,7 @@ export default async function WikiLayout({
     .select("id")
     .eq("workspace_id", workspace.id)
     .eq("user_id", user.id)
-    .single();
+    .maybeSingle();
   if (!member) redirect("/onboarding");
 
   return (

--- a/src/app/api/v1/bugs/[identifier]/route.ts
+++ b/src/app/api/v1/bugs/[identifier]/route.ts
@@ -16,7 +16,7 @@ export async function GET(
       .select("*")
       .eq("identifier", identifier.toUpperCase())
       .eq("workspace_id", workspaceId)
-      .single();
+      .maybeSingle();
 
     if (error) throw error;
     return apiSuccess(data);

--- a/src/app/api/v1/projects/route.ts
+++ b/src/app/api/v1/projects/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: Request) {
       .select("id")
       .eq("workspace_id", workspaceId)
       .limit(1)
-      .single();
+      .maybeSingle();
 
     const { data, error } = await supabase
       .from("projects")

--- a/src/app/api/v1/tasks/[identifier]/reminders/route.ts
+++ b/src/app/api/v1/tasks/[identifier]/reminders/route.ts
@@ -18,7 +18,7 @@ export async function POST(
       .select("id, assignee_id")
       .eq("identifier", identifier.toUpperCase())
       .eq("workspace_id", workspaceId)
-      .single();
+      .maybeSingle();
 
     if (!task) throw new Error("Task not found");
 
@@ -29,7 +29,7 @@ export async function POST(
         .from("workspace_members")
         .select("user_id")
         .eq("id", task.assignee_id)
-        .single();
+        .maybeSingle();
       userId = member?.user_id;
     }
 
@@ -40,7 +40,7 @@ export async function POST(
         .select("user_id")
         .eq("workspace_id", workspaceId)
         .limit(1)
-        .single();
+        .maybeSingle();
       userId = m?.user_id;
     }
 

--- a/src/app/api/v1/tasks/[identifier]/route.ts
+++ b/src/app/api/v1/tasks/[identifier]/route.ts
@@ -16,7 +16,7 @@ export async function GET(
       .select("*")
       .eq("identifier", identifier.toUpperCase())
       .eq("workspace_id", workspaceId)
-      .single();
+      .maybeSingle();
 
     if (error) throw error;
     return apiSuccess(data);

--- a/src/app/api/v1/webhooks/github/route.ts
+++ b/src/app/api/v1/webhooks/github/route.ts
@@ -106,7 +106,7 @@ async function handlePushEvent(
     .from("projects")
     .select("id, workspace_id")
     .ilike("github_repo_url", `%${repoFullName}%`)
-    .single();
+    .maybeSingle();
 
   if (!project) {
     console.log(`No project found for repository: ${repoFullName}`);
@@ -119,7 +119,7 @@ async function handlePushEvent(
     .select("id")
     .eq("workspace_id", project.workspace_id)
     .limit(1)
-    .single();
+    .maybeSingle();
 
   if (!member) return;
 
@@ -158,7 +158,7 @@ async function handlePullRequestEvent(
     .from("projects")
     .select("id, workspace_id")
     .ilike("github_repo_url", `%${repoFullName}%`)
-    .single();
+    .maybeSingle();
 
   if (!project) return;
 
@@ -211,7 +211,7 @@ async function handlePullRequestReviewEvent(
     .from("projects")
     .select("id, workspace_id")
     .ilike("github_repo_url", `%${repoFullName}%`)
-    .single();
+    .maybeSingle();
 
   if (!project) return;
 

--- a/src/hooks/use-channels.ts
+++ b/src/hooks/use-channels.ts
@@ -35,7 +35,7 @@ export function useChannel(channelId: string) {
         .from("channels")
         .select("*")
         .eq("id", channelId)
-        .single();
+        .maybeSingle();
 
       if (error) throw error;
       return data;

--- a/src/hooks/use-messages.ts
+++ b/src/hooks/use-messages.ts
@@ -182,7 +182,7 @@ export function useToggleReaction() {
         .from("messages")
         .select("reactions")
         .eq("id", messageId)
-        .single();
+        .maybeSingle();
 
       const reactions = (msg?.reactions ?? {}) as Record<string, string[]>;
       const emojiList = reactions[emoji] ?? [];

--- a/src/hooks/use-notification-preferences.ts
+++ b/src/hooks/use-notification-preferences.ts
@@ -59,9 +59,9 @@ export function useNotificationPreferences(
         .select("*")
         .eq("user_id", userId)
         .eq("workspace_id", workspaceId)
-        .single();
+        .maybeSingle();
 
-      if (error && error.code !== "PGRST116") throw error;
+      if (error) throw error;
 
       // Return existing preferences or defaults
       if (data) {

--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -36,7 +36,7 @@ export function useProject(projectSlug: string, workspaceId: string) {
         .select("*")
         .eq("workspace_id", workspaceId)
         .eq("slug", projectSlug)
-        .single();
+        .maybeSingle();
 
       if (error) throw error;
       return data;

--- a/src/hooks/use-scans.ts
+++ b/src/hooks/use-scans.ts
@@ -16,9 +16,9 @@ export function useLatestScan(projectId: string) {
         .eq("status", "completed")
         .order("completed_at", { ascending: false })
         .limit(1)
-        .single();
+        .maybeSingle();
 
-      if (error && error.code !== "PGRST116") throw error;
+      if (error) throw error;
       return data;
     },
     enabled: !!projectId,

--- a/src/hooks/use-wiki.ts
+++ b/src/hooks/use-wiki.ts
@@ -86,7 +86,7 @@ export function useWikiPage(pageId: string) {
         .from("wiki_pages")
         .select("*, last_editor:workspace_members!wiki_pages_last_edited_by_fkey(display_name)")
         .eq("id", pageId)
-        .single();
+        .maybeSingle();
 
       if (error) throw error;
       return data;
@@ -155,7 +155,7 @@ export function useUpdateWikiPage() {
           .from("wiki_pages")
           .select("content, title")
           .eq("id", id)
-          .single();
+          .maybeSingle();
 
         if (current) {
           await supabase.from("wiki_page_versions").insert({

--- a/src/hooks/use-workspace.ts
+++ b/src/hooks/use-workspace.ts
@@ -36,7 +36,7 @@ export function useWorkspace(slug: string) {
         .from("workspaces")
         .select("*")
         .eq("slug", slug)
-        .single();
+        .maybeSingle();
 
       if (error) throw error;
       return data;
@@ -62,7 +62,7 @@ export function useCurrentMember(workspaceId: string) {
         .eq("workspace_id", workspaceId)
         .eq("user_id", user.id)
         .eq("status", "active")
-        .single();
+        .maybeSingle();
 
       if (error) throw error;
       return data;

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -29,7 +29,7 @@ export async function authenticateAPIKey(
     .select("id, workspace_id, permissions, is_active, expires_at")
     .eq("key_prefix", prefix)
     .eq("key_hash", hash)
-    .single();
+    .maybeSingle();
 
   if (error || !key) {
     throw new APIError("UNAUTHORIZED", "Invalid API key", 401);

--- a/src/lib/export/pdf.ts
+++ b/src/lib/export/pdf.ts
@@ -72,7 +72,6 @@ function buildPrintableDocument(title: string, tableHtml: string): string {
   <h1>${escapeHtml(title)}</h1>
   <p class="meta">Exported on ${escapeHtml(exportDate)}</p>
   ${tableHtml}
-  <script>window.onload = function() { window.print(); };</script>
 </body>
 </html>`;
 }
@@ -114,6 +113,7 @@ export function exportTasksPDF(tasks: TaskRow[], projectName: string): void {
   if (win) {
     win.document.write(html);
     win.document.close();
+    win.onload = () => win.print();
   }
 }
 
@@ -154,5 +154,6 @@ export function exportBugsPDF(bugs: BugRow[], projectName: string): void {
   if (win) {
     win.document.write(html);
     win.document.close();
+    win.onload = () => win.print();
   }
 }

--- a/src/lib/scanning.ts
+++ b/src/lib/scanning.ts
@@ -43,7 +43,7 @@ export async function processScan(
       .from("repository_scans")
       .select("*, project:projects(github_repo_url)")
       .eq("id", scanId)
-      .single();
+      .maybeSingle();
 
     if (!scan) throw new Error("Scan not found");
 


### PR DESCRIPTION
Resolves #9
Resolves #11
Resolves #12

## Changes

### BUG-009: Analytics calculation
- Fixed task completion percentage by checking each project's configured final status (from `settings.statuses`) instead of relying on `completed_at` timestamps
- The `completed_at` trigger only fires on UPDATE, so tasks inserted directly with the final status were never counted
- Fixed Tasks per Member chart to use the same project-aware status check

### BUG-011: Script tag
- Removed inline `<script>` tag from PDF export HTML template
- Replaced with programmatic `win.onload` callback to trigger print dialog

### BUG-012: 406 errors
- Replaced `.single()` with `.maybeSingle()` across API routes and hooks where queries can legitimately return 0 rows
- Affected files: auth.ts, webhooks/github, projects, tasks/reminders, use-channels, use-messages, use-notification-preferences, scanning.ts

## Test plan
- [ ] Create tasks in different projects and verify analytics shows correct completion percentage
- [ ] Move a task to the project's final status and confirm it counts as completed
- [ ] Verify Tasks per Member chart shows correct completed/open split
- [ ] Export tasks/bugs to PDF and confirm print dialog opens
- [ ] Hit API endpoints with invalid/missing data and confirm no 406 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)